### PR TITLE
Add a directory for tips and add first tip

### DIFF
--- a/Tips/recovering_from_hangs.md
+++ b/Tips/recovering_from_hangs.md
@@ -1,0 +1,7 @@
+### Recovering from hangs
+
+Sometimes the application can hang during a processing event such as adding/optimizing supports or after completing a slice operation. You can sometimes recover from this hang by saving, closing and reopening the application then reloading your scene file.
+
+1. Use the save shortcode. Press `Crtl` + `s`
+1. Exit or force close the application.
+1. Reopen the application and load the saved scene.


### PR DESCRIPTION
The first tip is a method that can be used to save work when the application hangs/locks on a specific step